### PR TITLE
Fix fatal error when there is no close button on a notice

### DIFF
--- a/docs/src/js/components/notice.js
+++ b/docs/src/js/components/notice.js
@@ -29,6 +29,7 @@
 
 			/* add click event */
 			for (let i = 0; i < allNotice.length; i++) {
+				if (! toggle) continue;
 				toggle.addEventListener('click', function(e) {
 					e.preventDefault()
 					hide(this.parentNode)


### PR DESCRIPTION
When you don't have a close button on a "notice" the javascript died.
I'm just checking if it's undefined before using it.